### PR TITLE
Patch 1

### DIFF
--- a/ADMX/fr-FR/Mozilla.adml
+++ b/ADMX/fr-FR/Mozilla.adml
@@ -41,8 +41,7 @@ Si vous activez cette police, cette page sera supprimée.</string>
       <string id="MOZILLA_FIREFOX_LOCKED_PROXY_MANUALPRX">Configuration manuelle du proxy</string>
       <string id="MOZILLA_FIREFOX_LOCKED_PROXY_USEPAC">Utiliser la configuration automatique des URL (PAC)</string>	  
     <string id="MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE">Utiliser le Magasin de Certificats Windows</string>
-	  <string id="MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE_Help">Rechercher et importer automatiquement les CAs qui ont été ajoutées au magasin de certificats Windows par un utilisateur ou un administrateur
-.
+	  <string id="MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE_Help">Rechercher et importer automatiquement les CAs qui ont été ajoutées au magasin de certificats Windows par un utilisateur ou un administrateur.
 	  
 Nécessite Firefox 49 ou supérieur.</string> 
     </stringTable>

--- a/ADMX/fr-FR/Mozilla.adml
+++ b/ADMX/fr-FR/Mozilla.adml
@@ -40,6 +40,11 @@ Si vous activez cette police, cette page sera supprimée.</string>
       <string id="MOZILLA_FIREFOX_LOCKED_PROXY_USESYSTEM">Utiliser la configuration système</string>
       <string id="MOZILLA_FIREFOX_LOCKED_PROXY_MANUALPRX">Configuration manuelle du proxy</string>
       <string id="MOZILLA_FIREFOX_LOCKED_PROXY_USEPAC">Utiliser la configuration automatique des URL (PAC)</string>	  
+    <string id="MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE">Utiliser le Magasin de Certificats Windows</string>
+	  <string id="MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE_Help">Rechercher et importer automatiquement les CAs qui ont été ajoutées au magasin de certificats Windows par un utilisateur ou un administrateur
+.
+	  
+Nécessite Firefox 49 ou supérieur.</string> 
     </stringTable>
     <presentationTable>
       <presentation id="MOZILLA_FIREFOX_LOCKED_CUSTOM_HOMEPAGE">


### PR DESCRIPTION
missing lines in french version of ADML that generate error when opening template ( result in mozilla GPO not visible in template"
lines inserted after line 42 in ADML

Details
-------------------------------------------------------------------------------------------------------
`<string`` id="MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE">Utiliser le Magasin de Certificats `Windows</string>
	  <string` id="MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE_Help">Rechercher et importer automatiquement les CAs qui ont été ajoutées au magasin de certificats Windows par un utilisateur ou un administrateur.

	  Nécessite` Firefox 49 ou `supérieur.</string>`
---------------------------------------------------------------------

Error/Issue without these missing lines below:


An error has occurred while collecting data for Administrative Templates. The following errors were encountered: Resource ‘$(string.MOZILLA_FIREFOX_LOCKED_CERT_SYSTEM_STORE)’ referenced in attribute displayName could not be found. File C:\Windows\PolicyDefinitions\inetres.admx, line 183, column 279